### PR TITLE
Save the original UNUserNotificationDelegate before replacing it.

### DIFF
--- a/IosAwnCore/Classes/AwesomeNotifications.swift
+++ b/IosAwnCore/Classes/AwesomeNotifications.swift
@@ -515,8 +515,10 @@ public class AwesomeNotifications:
     private var _originalNotificationCenterDelegate: UNUserNotificationCenterDelegate?
     
     @objc public func didFinishLaunch(_ application: UIApplication) {
-        
-        UNUserNotificationCenter.current().delegate = self
+
+        let notificationCenter = UNUserNotificationCenter.current()
+        _originalNotificationCenterDelegate = notificationCenter.delegate
+        notificationCenter.delegate = self
         
         AwesomeNotifications.didFinishLaunch = true
         if AwesomeNotifications.completionHandlerGetInitialAction != nil {


### PR DESCRIPTION
This changes is related to the previous pull request:
https://github.com/rafaelsetragni/awesome_notifications/pull/274/files

Didn't know why the code of setting `_originalNotificationCenterDelegate` was missing on current version. 