### PR TITLE
Handle multiple audio extensions caf, aiff, wav, mp3) in getSoundFromResource

### DIFF
--- a/IosAwnCore.podspec
+++ b/IosAwnCore.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IosAwnCore'
-  s.version          = '0.10.0'
+  s.version          = '0.11.0'
   s.summary          = 'Awesome Notifications iOS Core'
 
   s.description      = <<-DESC

--- a/IosAwnCore.podspec
+++ b/IosAwnCore.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IosAwnCore'
-  s.version          = '0.11.0'
+  s.version          = '0.10.0'
   s.summary          = 'Awesome Notifications iOS Core'
 
   s.description      = <<-DESC

--- a/IosAwnCore/Classes/utils/AudioUtils.swift
+++ b/IosAwnCore/Classes/utils/AudioUtils.swift
@@ -117,21 +117,30 @@ open class AudioUtils: MediaUtils {
     open func getSoundFromResource(_ mediaPath:String) -> UNNotificationSound? {
         var mediaPath:String? = cleanMediaPath(mediaPath)
         
-        //do {
-            if mediaPath!.replaceRegex("^.*\\/([^\\/]+)$", replaceWith: "$1") {
-                var topPath:String? = Bundle.main.url(forResource: mediaPath!, withExtension: "aiff")?.absoluteString
+        // copy to mutable variable
+        var name = mediaPath
+        
+        // replaceRegex returns Bool match/success, and mutates the variable 'name'
+        if name != nil && name!.replaceRegex("^.*\\/([^\\/]+)$", replaceWith: "$1") {
                 
-                if ((topPath?.replaceRegex("^.*\\/([^\\/]+)$", replaceWith: "$1")) != nil){
-                    return UNNotificationSound(named: UNNotificationSoundName(rawValue: topPath!))
+            // 1. Try with the extensions (caf, aiff, wav, mp3)
+            let extensions = ["caf", "aiff", "wav", "mp3"]
+            
+            for ext in extensions {
+                if let validName = name, let path = Bundle.main.path(forResource: validName, ofType: ext) {
+                     return UNNotificationSound(named: UNNotificationSoundName(rawValue: "\(validName).\(ext)"))
                 }
-                return UNNotificationSound.default
             }
-            return nil
-          /*
-        } catch let error {
-            Logger.shared.e("AudioUtils", error)
-            return nil
-        }*/
+            
+            // 2. Fallback to original behavior
+            var topPath:String? = Bundle.main.url(forResource: mediaPath!, withExtension: "aiff")?.absoluteString
+            
+            if ((topPath?.replaceRegex("^.*\\/([^\\/]+)$", replaceWith: "$1")) != nil){
+                return UNNotificationSound(named: UNNotificationSoundName(rawValue: topPath!))
+            }
+            return UNNotificationSound.default
+        }
+        return nil
     }
     
     public func isValidSound(_ mediaPath:String?) -> Bool {


### PR DESCRIPTION
Refactor getSoundFromResource to copy mediaPath into a mutable variable and use replaceRegex correctly to extract the filename. Attempt to locate the resource using common audio extensions (caf, aiff, wav, mp3) and return a UNNotificationSound built from the matching filename and extension. If no extension match is found, fall back to the previous aiff URL-based behavior and finally to UNNotificationSound.default; otherwise return nil. Also clean up leftover commented-out try/catch logic and simplify control flow.