### PR TITLE
fix(ios): Critical Alerts

### DIFF
--- a/IosAwnCore/Classes/Definitions.swift
+++ b/IosAwnCore/Classes/Definitions.swift
@@ -110,6 +110,7 @@ public enum Definitions {
     public static let  CHANNEL_METHOD_IS_NOTIFICATION_ALLOWED = "isNotificationAllowed"
     public static let  CHANNEL_METHOD_REQUEST_NOTIFICATIONS = "requestNotifications"
     public static let  CHANNEL_METHOD_CHECK_PERMISSIONS = "checkPermissions"
+    public static let  CHANNEL_METHOD_GET_PERMISSION_STATUSES = "getPermissionStatuses"
     public static let  CHANNEL_METHOD_SHOULD_SHOW_RATIONALE = "shouldShowRationale"
 
     public static let  CHANNEL_METHOD_DISMISS_NOTIFICATION = "dismissNotification"
@@ -206,6 +207,7 @@ public enum Definitions {
     public static let  NOTIFICATION_ENABLED = "enabled"
     public static let  NOTIFICATION_AUTO_DISMISSIBLE = "autoDismissible"
     public static let  NOTIFICATION_LOCKED = "locked"
+    public static let  NOTIFICATION_CRITICAL_ALERT = "criticalAlert"
     public static let  NOTIFICATION_DISPLAY_ON_FOREGROUND = "displayOnForeground"
     public static let  NOTIFICATION_DISPLAY_ON_BACKGROUND = "displayOnBackground"
     public static let  NOTIFICATION_ICON = "icon"

--- a/IosAwnCore/Classes/builders/NotificationBuilder.swift
+++ b/IosAwnCore/Classes/builders/NotificationBuilder.swift
@@ -158,7 +158,7 @@ public class NotificationBuilder {
                 content: content)
         
         setWakeUpScreen(notificationModel: notificationModel, content: content)
-        setCriticalAlert(channel: channel, content: content)
+        setCriticalAlert(channel: channel, notificationModel: notificationModel, content: content)
         
         let requiredActions = listRequiredActions(notificationModel: notificationModel)
         setUserInfoContent(notificationModel: notificationModel, requiredActions: requiredActions, content: content)
@@ -505,7 +505,34 @@ public class NotificationBuilder {
     }
 
     private func setSound(notificationModel:NotificationModel, channel:NotificationChannelModel, content:UNMutableNotificationContent){
-        
+        let criticalRequested = CriticalAlertUtils.isCriticalAlertRequested(
+            channel: channel,
+            notificationModel: notificationModel)
+
+        if criticalRequested && CriticalAlertUtils.canDeliverCriticalAlerts() {
+            if (notificationModel.content!.playSound ?? false) && (channel.playSound ?? false) {
+                if #available(iOS 12.0, *) {
+                    if !StringUtils.shared.isNullOrEmpty(notificationModel.content!.customSound) {
+                        content.sound = AudioUtils.shared.getSoundFromSource(
+                            SoundPath: notificationModel.content!.customSound!)
+                        return
+                    }
+
+                    if !StringUtils.shared.isNullOrEmpty(channel.soundSource) {
+                        content.sound = AudioUtils.shared.getSoundFromSource(
+                            SoundPath: channel.soundSource!)
+                        return
+                    }
+
+                    content.sound = UNNotificationSound.defaultCritical
+                    return
+                }
+            } else {
+                content.sound = nil
+            }
+            return
+        }
+
         switch notificationModel.importance ?? .Default {
             
             case .Default, .High, .Max:
@@ -567,11 +594,23 @@ public class NotificationBuilder {
         }
     }
     
-    private func setCriticalAlert(channel:NotificationChannelModel, content:UNMutableNotificationContent){
-        if channel.criticalAlerts ?? false {
-            if #available(iOS 15.0, *) {
-                content.interruptionLevel = .critical
-            }
+    private func setCriticalAlert(
+        channel: NotificationChannelModel,
+        notificationModel: NotificationModel,
+        content: UNMutableNotificationContent
+    ){
+        let requested = CriticalAlertUtils.isCriticalAlertRequested(
+            channel: channel,
+            notificationModel: notificationModel)
+        guard requested else { return }
+
+        guard CriticalAlertUtils.canDeliverCriticalAlerts() else {
+            Logger.shared.d(TAG, "Critical alert requested but not available; using standard delivery")
+            return
+        }
+
+        if #available(iOS 15.0, *) {
+            content.interruptionLevel = .critical
         }
     }
 

--- a/IosAwnCore/Classes/enumerators/NotificationPermissionStatus.swift
+++ b/IosAwnCore/Classes/enumerators/NotificationPermissionStatus.swift
@@ -1,0 +1,10 @@
+public enum NotificationPermissionStatus : String, CaseIterable {
+    case granted = "granted"
+    case denied = "denied"
+    case notDetermined = "notDetermined"
+    case notSupported = "notSupported"
+
+    static func fromString(_ label: String) -> NotificationPermissionStatus? {
+        return self.allCases.first { "\($0)" == label }
+    }
+}

--- a/IosAwnCore/Classes/managers/PermissionManager.swift
+++ b/IosAwnCore/Classes/managers/PermissionManager.swift
@@ -84,6 +84,7 @@ public class PermissionManager {
         
         let current = UNUserNotificationCenter.current()
         current.getNotificationSettings(completionHandler: { (settings) in
+            CriticalAlertUtils.updateCache(from: settings)
             
             if settings.authorizationStatus == .notDetermined {
                 // The user hasnt decided yet if he authorizes or not
@@ -99,7 +100,22 @@ public class PermissionManager {
                 // Notification permission was already granted
                 permissionCompletion(true)
                 return
+
+            } else if #available(iOS 12.0, *) {
+                if settings.authorizationStatus == .provisional {
+                    permissionCompletion(true)
+                    return
+                }
             }
+
+            if #available(iOS 14.0, *) {
+                if settings.authorizationStatus == .ephemeral {
+                    permissionCompletion(true)
+                    return
+                }
+            }
+
+            permissionCompletion(false)
         })
         
         //return UIApplication.shared.isRegisteredForRemoteNotifications
@@ -120,6 +136,7 @@ public class PermissionManager {
             }
             
             UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { iOSpermissions in
+                CriticalAlertUtils.updateCache(from: iOSpermissions)
                 
                 for permission in permissions {
                     if let permissionEnum:NotificationPermission = NotificationPermission.fromString(permission) {
@@ -151,7 +168,8 @@ public class PermissionManager {
                             case .OverrideDnD: fallthrough
                             case .CriticalAlert:
                                 if #available(iOS 12.0, *) {
-                                    if(iOSpermissions.criticalAlertSetting == .disabled){
+                                    if iOSpermissions.criticalAlertSetting != .enabled &&
+                                        iOSpermissions.criticalAlertSetting != .notSupported {
                                         shouldShowRationaleList.append(NotificationPermission.CriticalAlert.rawValue)
                                     }
                                 }
@@ -192,6 +210,7 @@ public class PermissionManager {
             }
             
             UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { iOSpermissions in
+                CriticalAlertUtils.updateCache(from: iOSpermissions)
                 
                 // (Settings != .Disabled == .Enabled & .NotSupported /*Emulator limitations*/)
                 for permission in permissions {
@@ -278,6 +297,7 @@ public class PermissionManager {
     public func isSpecifiedPermissionGloballyAllowed(_ permission:String, channel:String?, completion: @escaping (Bool) -> ()){
 
         UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { iOSpermissions in
+            CriticalAlertUtils.updateCache(from: iOSpermissions)
             
             // (Settings != .Disabled == .Enabled & .NotSupported /*Emulator limitations*/)
             switch NotificationPermission.fromString(permission) {
@@ -367,6 +387,211 @@ public class PermissionManager {
         return false
     }
 
+    public func getPermissionStatuses(
+        _ permissions:[String],
+        filteringByChannelKey channelKey:String?,
+        whenGotResults completion: @escaping ([String:String]) -> ()
+    ) {
+        if SwiftUtils.isRunningOnExtension() {
+            var statuses:[String:String] = [:]
+            for permission in permissions {
+                statuses[permission] = NotificationPermissionStatus.granted.rawValue
+            }
+            completion(statuses)
+            return
+        }
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            CriticalAlertUtils.updateCache(from: settings)
+
+            var statuses:[String:String] = [:]
+            for permission in permissions {
+                statuses[permission] = self.resolvePermissionStatus(
+                    permission: permission,
+                    settings: settings,
+                    channelKey: channelKey)
+            }
+            completion(statuses)
+        }
+    }
+
+    private func resolvePermissionStatus(
+        permission:String,
+        settings:UNNotificationSettings,
+        channelKey:String?
+    ) -> String {
+        guard let permissionEnum = NotificationPermission.fromString(permission) else {
+            return NotificationPermissionStatus.notSupported.rawValue
+        }
+
+        switch permissionEnum {
+            case .CriticalAlert, .OverrideDnD:
+                return resolveCriticalAlertPermissionStatus(settings: settings)
+
+            case .Alert:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.alertSetting)
+
+            case .Sound:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.soundSetting)
+
+            case .Badge:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.badgeSetting)
+
+            case .Car:
+                return resolveNotificationSettingStatus(
+                    settings: settings,
+                    setting: settings.carPlaySetting)
+
+            case .Provisional:
+                if #available(iOS 12.0, *) {
+                    if settings.authorizationStatus == .provisional {
+                        return NotificationPermissionStatus.granted.rawValue
+                    }
+                    if settings.authorizationStatus == .notDetermined {
+                        return NotificationPermissionStatus.notDetermined.rawValue
+                    }
+                    if settings.authorizationStatus == .denied {
+                        return NotificationPermissionStatus.denied.rawValue
+                    }
+                    return NotificationPermissionStatus.notDetermined.rawValue
+                }
+                return NotificationPermissionStatus.notSupported.rawValue
+
+            default:
+                if channelKey == nil ||
+                    isSpecifiedChannelPermissionAllowed(
+                        channelKey: channelKey!,
+                        permissionEnum: permissionEnum) {
+                    return NotificationPermissionStatus.granted.rawValue
+                }
+                return NotificationPermissionStatus.denied.rawValue
+        }
+    }
+
+    private func resolveNotificationSettingStatus(
+        settings:UNNotificationSettings,
+        setting:UNNotificationSetting
+    ) -> String {
+        if settings.authorizationStatus == .notDetermined {
+            return NotificationPermissionStatus.notDetermined.rawValue
+        }
+        if settings.authorizationStatus == .denied {
+            return NotificationPermissionStatus.denied.rawValue
+        }
+        switch setting {
+            case .enabled:
+                return NotificationPermissionStatus.granted.rawValue
+            case .notSupported:
+                return NotificationPermissionStatus.notSupported.rawValue
+            default:
+                return NotificationPermissionStatus.denied.rawValue
+        }
+    }
+
+    @available(iOS 12.0, *)
+    private func resolveCriticalAlertPermissionStatus(
+        settings:UNNotificationSettings
+    ) -> String {
+        switch settings.criticalAlertSetting {
+            case .enabled:
+                return NotificationPermissionStatus.granted.rawValue
+            case .notSupported:
+                if self.isBaseNotificationAuthorizationGranted(settings) {
+                    return NotificationPermissionStatus.notDetermined.rawValue
+                }
+                return NotificationPermissionStatus.notSupported.rawValue
+            default:
+                break
+        }
+
+        if settings.authorizationStatus == .notDetermined {
+            return NotificationPermissionStatus.notDetermined.rawValue
+        }
+        if settings.authorizationStatus == .denied {
+            return NotificationPermissionStatus.denied.rawValue
+        }
+        return NotificationPermissionStatus.notDetermined.rawValue
+    }
+
+    private func isBaseNotificationAuthorizationGranted(_ settings: UNNotificationSettings) -> Bool {
+        if #available(iOS 12.0, *) {
+            return settings.authorizationStatus == .authorized ||
+                settings.authorizationStatus == .provisional
+        }
+        return settings.authorizationStatus == .authorized
+    }
+
+    @available(iOS 12.0, *)
+    private func isCriticalAlertEntitlementMissing(_ settings: UNNotificationSettings) -> Bool {
+        return settings.criticalAlertSetting == .notSupported &&
+            !isBaseNotificationAuthorizationGranted(settings)
+    }
+
+    @available(iOS 12.0, *)
+    private func shouldRequestCriticalAlertAuthorization(_ settings: UNNotificationSettings) -> Bool {
+        if settings.criticalAlertSetting == .disabled {
+            return true
+        }
+        if settings.criticalAlertSetting == .notSupported &&
+            isBaseNotificationAuthorizationGranted(settings) {
+            return true
+        }
+        return false
+    }
+
+    private func iosCriticalAlertAuthorizationPermissions() -> [String] {
+        return [
+            NotificationPermission.Alert.rawValue,
+            NotificationPermission.Sound.rawValue,
+            NotificationPermission.Badge.rawValue,
+            NotificationPermission.CriticalAlert.rawValue
+        ]
+    }
+
+    private func requestCriticalAlertPermissionIfNeeded(
+        permissionsNeeded:[String],
+        permissionsRequested:[String],
+        settings:UNNotificationSettings,
+        channelKey:String?,
+        permissionCompletion: @escaping ([String]) -> ()
+    ) -> Bool {
+        guard #available(iOS 12.0, *) else { return false }
+
+        let needsCriticalAlertPermission =
+            permissionsRequested.contains(NotificationPermission.CriticalAlert.rawValue) ||
+            permissionsRequested.contains(NotificationPermission.OverrideDnD.rawValue)
+
+        guard needsCriticalAlertPermission else { return false }
+        guard isBaseNotificationAuthorizationGranted(settings) else { return false }
+        guard settings.criticalAlertSetting != .enabled else { return false }
+
+        if self.isCriticalAlertEntitlementMissing(settings) {
+            Logger.shared.e(self.TAG,
+                "Critical Alerts are not available for this project. " +
+                "You must require Apple special permissions to use it. " +
+                "For more informations, please read our official documentation.")
+            permissionCompletion(permissionsNeeded)
+            return true
+        }
+
+        if self.shouldRequestCriticalAlertAuthorization(settings) {
+            self.showRequestDialog(
+                channelKey: nil,
+                permissionsNeeded: permissionsNeeded,
+                permissionsToRequest: self.iosCriticalAlertAuthorizationPermissions(),
+                permissionCompletion: permissionCompletion)
+            return true
+        }
+
+        return false
+    }
+
     public func requestUserPermissions(
         _ permissions:[String],
         filteringByChannelKey channelKey:String?,
@@ -394,6 +619,7 @@ public class PermissionManager {
                 
                 else {
                     UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+                        CriticalAlertUtils.updateCache(from: settings)
                         
                         var isAllowed:Bool = false
                         if #available(iOS 12.0, *) {
@@ -408,7 +634,7 @@ public class PermissionManager {
                         if #available(iOS 12.0, *) {
                             if permissionsRequested.contains(NotificationPermission.CriticalAlert.rawValue) ||
                                 permissionsRequested.contains(NotificationPermission.OverrideDnD.rawValue){
-                                if(settings.criticalAlertSetting == .notSupported){
+                                if self.isCriticalAlertEntitlementMissing(settings) {
                                     Logger.shared.e(self.TAG,
                                         "Critical Alerts are not available for this project. " +
                                         "You must require Apple special permissions to use it. " +
@@ -418,7 +644,7 @@ public class PermissionManager {
                                         return
                                     }
                                     permissionsRequested = permissionsRequested.filter {
-                                        ![NotificationPermission.CriticalAlert.rawValue, NotificationPermission.CriticalAlert.rawValue].contains($0)
+                                        ![NotificationPermission.CriticalAlert.rawValue, NotificationPermission.OverrideDnD.rawValue].contains($0)
                                     }
                                 }
                             }
@@ -426,6 +652,15 @@ public class PermissionManager {
                         
                         if permissionsRequested.isEmpty {
                             permissionCompletion(permissions)
+                            return
+                        }
+
+                        if self.requestCriticalAlertPermissionIfNeeded(
+                            permissionsNeeded: permissionsNeeded,
+                            permissionsRequested: permissionsRequested,
+                            settings: settings,
+                            channelKey: channelKey,
+                            permissionCompletion: permissionCompletion) {
                             return
                         }
 
@@ -442,7 +677,7 @@ public class PermissionManager {
                             
                             if listToShowRationale.count == 1 {
                                 
-                                guard let permissionEnum = NotificationPermission.fromString(permissionsNeeded.first!) else {
+                                guard let permissionEnum = NotificationPermission.fromString(listToShowRationale.first!) else {
                                     self.refreshReturnedPermissions(
                                         permissionsNeeded,
                                         filteringByChannelKey: channelKey,
@@ -455,11 +690,11 @@ public class PermissionManager {
                                     case .OverrideDnD: fallthrough
                                     case .CriticalAlert:
                                         if #available(iOS 12.0, *) {
-                                            if(settings.criticalAlertSetting == .disabled){
+                                            if self.shouldRequestCriticalAlertAuthorization(settings) {
                                                 self.showRequestDialog(
-                                                    channelKey: channelKey,
+                                                    channelKey: nil,
                                                     permissionsNeeded: permissionsNeeded,
-                                                    permissionsToRequest: listToShowRationale,
+                                                    permissionsToRequest: self.iosCriticalAlertAuthorizationPermissions(),
                                                     permissionCompletion: permissionCompletion)
                                                 return
                                             }
@@ -500,6 +735,7 @@ public class PermissionManager {
         
         let iOSpermissions:UNAuthorizationOptions = getIosPermissionsCode(permissionsToRequest)
         UNUserNotificationCenter.current().requestAuthorization(options: iOSpermissions) { (granted, error) in
+            CriticalAlertUtils.clearCache()
 
             if granted {
                 Logger.shared.d("PermissionManager", "Permissions enabled successfully")

--- a/IosAwnCore/Classes/models/NotificationChannelModel.swift
+++ b/IosAwnCore/Classes/models/NotificationChannelModel.swift
@@ -122,7 +122,7 @@ public class NotificationChannelModel : AbstractModel {
         if(locked != nil) {mapData[Definitions.NOTIFICATION_LOCKED] = self.locked}
         if(onlyAlertOnce != nil) {mapData[Definitions.NOTIFICATION_ONLY_ALERT_ONCE] = self.onlyAlertOnce}
         
-        if(criticalAlerts != nil) {mapData[Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS] = self.locked}
+        if(criticalAlerts != nil) {mapData[Definitions.NOTIFICATION_CHANNEL_CRITICAL_ALERTS] = self.criticalAlerts}
 
         if(defaultPrivacy != nil) {mapData[Definitions.NOTIFICATION_DEFAULT_PRIVACY] = self.defaultPrivacy?.rawValue}
         

--- a/IosAwnCore/Classes/models/NotificationContentModel.swift
+++ b/IosAwnCore/Classes/models/NotificationContentModel.swift
@@ -28,6 +28,7 @@ public class NotificationContentModel : AbstractModel {
     public var payload:[String:String?]?
     
     public var wakeUpScreen: Bool?
+    public var criticalAlert: Bool?
     public var playSound: Bool?
     public var customSound: String?
     public var locked: Bool?
@@ -141,6 +142,7 @@ public class NotificationContentModel : AbstractModel {
         self.customSound           = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CUSTOM_SOUND, arguments: arguments)
         
         self.wakeUpScreen          = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_WAKE_UP_SCREEN, arguments: arguments)
+        self.criticalAlert         = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CRITICAL_ALERT, arguments: arguments)
         self.locked                = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_LOCKED, arguments: arguments)
         self.icon                  = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_ICON, arguments: arguments)
         self.largeIcon             = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_LARGE_ICON, arguments: arguments)
@@ -198,6 +200,7 @@ public class NotificationContentModel : AbstractModel {
         
         if(self.summary != nil){ mapData[Definitions.NOTIFICATION_SUMMARY] = self.summary }
         if(self.wakeUpScreen != nil){ mapData[Definitions.NOTIFICATION_WAKE_UP_SCREEN] = self.wakeUpScreen }
+        if(self.criticalAlert != nil){ mapData[Definitions.NOTIFICATION_CRITICAL_ALERT] = self.criticalAlert }
         if(self.showWhen != nil){ mapData[Definitions.NOTIFICATION_SHOW_WHEN] = self.showWhen }
         if(self.playSound != nil){ mapData[Definitions.NOTIFICATION_PLAY_SOUND] = self.playSound }
         if(self.customSound != nil){ mapData[Definitions.NOTIFICATION_CUSTOM_SOUND] = self.customSound }

--- a/IosAwnCore/Classes/utils/CriticalAlertUtils.swift
+++ b/IosAwnCore/Classes/utils/CriticalAlertUtils.swift
@@ -1,0 +1,53 @@
+//
+//  CriticalAlertUtils.swift
+//  IosAwnCore
+//
+
+import Foundation
+import UserNotifications
+
+@available(iOS 10.0, *)
+public class CriticalAlertUtils {
+
+    private static var cachedCanDeliver: Bool?
+
+    public static func updateCache(from settings: UNNotificationSettings) {
+        if #available(iOS 12.0, *) {
+            cachedCanDeliver = settings.criticalAlertSetting == .enabled
+        } else {
+            cachedCanDeliver = false
+        }
+    }
+
+    public static func clearCache() {
+        cachedCanDeliver = nil
+    }
+
+    public static func canDeliverCriticalAlerts() -> Bool {
+        if let cachedCanDeliver = cachedCanDeliver {
+            return cachedCanDeliver
+        }
+
+        var canDeliver = false
+        let semaphore = DispatchSemaphore(value: 0)
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            if #available(iOS 12.0, *) {
+                canDeliver = settings.criticalAlertSetting == .enabled
+            }
+            cachedCanDeliver = canDeliver
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + 2)
+        return canDeliver
+    }
+
+    public static func isCriticalAlertRequested(
+        channel: NotificationChannelModel,
+        notificationModel: NotificationModel
+    ) -> Bool {
+        return (channel.criticalAlerts ?? false) ||
+            (notificationModel.content?.criticalAlert ?? false)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes iOS Critical Alerts when base notifications are already granted. With a valid Apple entitlement, iOS can report `criticalAlertSetting == .notSupported` before the first explicit request. The previous code treated that as a missing entitlement, skipped `requestAuthorization`, and the Critical Alerts toggle never appeared in Settings.

## What changed

**PermissionManager**
- Added helpers to tell missing entitlement apart from an iOS false positive
- When requestable, calls `requestAuthorization` with Alert, Sound, Badge, and CriticalAlert
- Maps status so authorized + `.notSupported` becomes `notDetermined`, not `notSupported`
- Uses explicit `self.` in escaping closures (Swift compile requirement)

**CriticalAlertUtils**
- Caches notification settings and gates critical delivery on real permission state

**NotificationBuilder**
- Applies critical interruption level and critical sound only when allowed
- Falls back to normal delivery when entitlement or permission is missing

**Models**
- Fixed channel persistence: `criticalAlerts` was saved as `locked` in `toMap()`
- Added `criticalAlert` on notification content

**NotificationPermissionStatus**
- Enum for permission status mapping inside PermissionManager

## Why

Without these changes, apps with a valid Apple entitlement could never request Critical Alerts after granting basic notifications. Delivery could also corrupt channel config or ignore the content-level critical flag.

## Test plan

- [ ] Real device with Apple Critical Alerts entitlement
- [ ] Base notifications granted → request CriticalAlert → system dialog appears
- [ ] No false “Critical Alerts not available” abort
- [ ] App without entitlement → graceful fallback, no crash