### PR TITLE
fix(ios): resolve critical-alert availability without blocking

### DIFF
--- a/IosAwnCore/Classes/threads/NotificationSenderAndScheduler.swift
+++ b/IosAwnCore/Classes/threads/NotificationSenderAndScheduler.swift
@@ -100,7 +100,16 @@ public class NotificationSenderAndScheduler {
             
             do {
                 if (allowed){
-                    try self.execute(completion: completion)
+                    // Resolve critical-alert availability (async, non-blocking)
+                    // before building, so the synchronous check in the builder
+                    // always sees the real value — including in an app extension.
+                    CriticalAlertUtils.ensureAvailabilityResolved {
+                        do {
+                            try self.execute(completion: completion)
+                        } catch {
+                            completion(false, nil, error)
+                        }
+                    }
                 }
                 else {
                     throw ExceptionFactory

--- a/IosAwnCore/Classes/utils/CriticalAlertUtils.swift
+++ b/IosAwnCore/Classes/utils/CriticalAlertUtils.swift
@@ -23,24 +23,34 @@ public class CriticalAlertUtils {
         cachedCanDeliver = nil
     }
 
+    /// Whether critical alerts can be delivered right now.
+    ///
+    /// A pure, non-blocking cache read. The value is resolved asynchronously
+    /// before the notification is built (see [ensureAvailabilityResolved]), so by
+    /// the time this is called from the build path the cache already holds the
+    /// real value. Defaults to `false` only if it was never resolved.
     public static func canDeliverCriticalAlerts() -> Bool {
-        if let cachedCanDeliver = cachedCanDeliver {
-            return cachedCanDeliver
+        return cachedCanDeliver ?? false
+    }
+
+    /// Resolves the critical-alert availability into the cache (asynchronously,
+    /// without blocking) and then runs [then].
+    ///
+    /// Call this in the already-async notification send flow, right before
+    /// building, so the synchronous [canDeliverCriticalAlerts] always reads a
+    /// fresh value. If the cache is already populated it runs [then] immediately;
+    /// otherwise it queries the settings once, updates the cache, and continues.
+    /// This covers the app-extension path too, where the global permission check
+    /// short-circuits and would otherwise leave the cache cold.
+    public static func ensureAvailabilityResolved(_ then: @escaping () -> Void) {
+        if cachedCanDeliver != nil {
+            then()
+            return
         }
-
-        var canDeliver = false
-        let semaphore = DispatchSemaphore(value: 0)
-
         UNUserNotificationCenter.current().getNotificationSettings { settings in
-            if #available(iOS 12.0, *) {
-                canDeliver = settings.criticalAlertSetting == .enabled
-            }
-            cachedCanDeliver = canDeliver
-            semaphore.signal()
+            updateCache(from: settings)
+            then()
         }
-
-        _ = semaphore.wait(timeout: .now() + 2)
-        return canDeliver
     }
 
     public static func isCriticalAlertRequested(


### PR DESCRIPTION
Follow-up to #9.

`canDeliverCriticalAlerts()` is called synchronously while building every notification. It previously blocked the calling thread on a `DispatchSemaphore` (up to 2s) on a cold cache — risking UI/watchdog stalls and, worst of all, tight-budget hangs in a Notification Service Extension (where push-delivered critical alerts are built).

This resolves the availability **asynchronously before building** and makes the synchronous check a pure cache read:
- `canDeliverCriticalAlerts()` returns the cached value (never blocks).
- `CriticalAlertUtils.ensureAvailabilityResolved(_:)` queries the settings once (async), updates the cache, then continues — run from the already-async send flow before building. In the app the global permission check already warms the cache; in an app extension it short-circuits, so this guarantees the real value is known before the build there too.

Keeps the correctness the original blocking code guaranteed, without ever blocking, and fixes the extension case where a cold cache would otherwise mis-report availability.