### PR TITLE
fix(ios): make critical alerts a channel-only capability (0.12.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ DerivedData
 *.hmap
 *.ipa
 
+# Swift Package Manager
+.build/
+
 # Bundler
 .bundle
 

--- a/IosAwnCore.podspec
+++ b/IosAwnCore.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IosAwnCore'
-  s.version          = '0.12.0'
+  s.version          = '0.12.1'
   s.summary          = 'Awesome Notifications iOS Core'
 
   s.description      = <<-DESC

--- a/IosAwnCore/Classes/Definitions.swift
+++ b/IosAwnCore/Classes/Definitions.swift
@@ -207,7 +207,6 @@ public enum Definitions {
     public static let  NOTIFICATION_ENABLED = "enabled"
     public static let  NOTIFICATION_AUTO_DISMISSIBLE = "autoDismissible"
     public static let  NOTIFICATION_LOCKED = "locked"
-    public static let  NOTIFICATION_CRITICAL_ALERT = "criticalAlert"
     public static let  NOTIFICATION_DISPLAY_ON_FOREGROUND = "displayOnForeground"
     public static let  NOTIFICATION_DISPLAY_ON_BACKGROUND = "displayOnBackground"
     public static let  NOTIFICATION_ICON = "icon"

--- a/IosAwnCore/Classes/models/NotificationContentModel.swift
+++ b/IosAwnCore/Classes/models/NotificationContentModel.swift
@@ -28,7 +28,6 @@ public class NotificationContentModel : AbstractModel {
     public var payload:[String:String?]?
     
     public var wakeUpScreen: Bool?
-    public var criticalAlert: Bool?
     public var playSound: Bool?
     public var customSound: String?
     public var locked: Bool?
@@ -142,7 +141,6 @@ public class NotificationContentModel : AbstractModel {
         self.customSound           = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_CUSTOM_SOUND, arguments: arguments)
         
         self.wakeUpScreen          = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_WAKE_UP_SCREEN, arguments: arguments)
-        self.criticalAlert         = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_CRITICAL_ALERT, arguments: arguments)
         self.locked                = MapUtils<Bool>.getValueOrDefault(reference: Definitions.NOTIFICATION_LOCKED, arguments: arguments)
         self.icon                  = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_ICON, arguments: arguments)
         self.largeIcon             = MapUtils<String>.getValueOrDefault(reference: Definitions.NOTIFICATION_LARGE_ICON, arguments: arguments)
@@ -200,7 +198,6 @@ public class NotificationContentModel : AbstractModel {
         
         if(self.summary != nil){ mapData[Definitions.NOTIFICATION_SUMMARY] = self.summary }
         if(self.wakeUpScreen != nil){ mapData[Definitions.NOTIFICATION_WAKE_UP_SCREEN] = self.wakeUpScreen }
-        if(self.criticalAlert != nil){ mapData[Definitions.NOTIFICATION_CRITICAL_ALERT] = self.criticalAlert }
         if(self.showWhen != nil){ mapData[Definitions.NOTIFICATION_SHOW_WHEN] = self.showWhen }
         if(self.playSound != nil){ mapData[Definitions.NOTIFICATION_PLAY_SOUND] = self.playSound }
         if(self.customSound != nil){ mapData[Definitions.NOTIFICATION_CUSTOM_SOUND] = self.customSound }

--- a/IosAwnCore/Classes/utils/CriticalAlertUtils.swift
+++ b/IosAwnCore/Classes/utils/CriticalAlertUtils.swift
@@ -53,11 +53,17 @@ public class CriticalAlertUtils {
         }
     }
 
+    /// Whether the notification's *channel* requests critical alerts.
+    ///
+    /// Critical is a **channel-level** capability, matching Android (where
+    /// DnD-bypass is a `NotificationChannel` property with no per-notification
+    /// override). A notification is critical only if its channel is critical —
+    /// there is no per-notification `criticalAlert` flag, so the rule is
+    /// identical on both platforms.
     public static func isCriticalAlertRequested(
         channel: NotificationChannelModel,
         notificationModel: NotificationModel
     ) -> Bool {
-        return (channel.criticalAlerts ?? false) ||
-            (notificationModel.content?.criticalAlert ?? false)
+        return channel.criticalAlerts ?? false
     }
 }


### PR DESCRIPTION
## Summary
Make critical alerts a **channel-only** capability, identical on iOS and Android.

Critical is now gated solely by the notification's channel (`channel.criticalAlerts`), matching the platform where it is inherently channel-scoped. The per-notification `content.criticalAlert` flag is removed. Same rule on both platforms — no surprises across devices.

## Changes
- `isCriticalAlertRequested` returns only `channel.criticalAlerts`
- remove the `content.criticalAlert` field (declaration, `fromMap`, `toMap`) and its `NOTIFICATION_CRITICAL_ALERT` key
- an incoming legacy `criticalAlert` content key is simply ignored (unknown key, harmless)
- gitignore the SwiftPM `.build/` directory
- bump to **0.12.1**

## Behavior / migration
Apps relying **only** on `content.criticalAlert` on a non-critical channel will no longer be critical — by design. Register the channel with `criticalAlerts: true` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)